### PR TITLE
AiStone X4SP4NAL DMI table entry and feature descriptor

### DIFF
--- a/uniwill-acpi.c
+++ b/uniwill-acpi.c
@@ -2360,6 +2360,18 @@ static struct uniwill_device_descriptor phxarx1_phxaqf1_descriptor __initdata = 
 	.probe = phxarx1_phxaqf1_probe,
 };
 
+static struct uniwill_device_descriptor x4sp4nal_descriptor __initdata = {
+	.features = UNIWILL_FEATURE_FN_LOCK |
+		    UNIWILL_FEATURE_SUPER_KEY |
+		    UNIWILL_FEATURE_BATTERY_CHARGE_MODES |
+		    UNIWILL_FEATURE_CPU_TEMP |
+		    UNIWILL_FEATURE_PRIMARY_FAN |
+		    UNIWILL_FEATURE_SECONDARY_FAN |
+		    UNIWILL_FEATURE_KEYBOARD_BACKLIGHT |
+		    UNIWILL_FEATURE_AC_AUTO_BOOT |
+		    UNIWILL_FEATURE_USB_POWERSHARE,
+};
+
 static struct uniwill_device_descriptor xxkk4nax_xxsp4nax_descriptor __initdata = {
 	.features = UNIWILL_FEATURE_FN_LOCK |
 		    UNIWILL_FEATURE_SUPER_KEY |
@@ -2379,6 +2391,14 @@ static struct uniwill_device_descriptor tux_featureset_1_descriptor __initdata =
 static struct uniwill_device_descriptor empty_descriptor __initdata = {};
 
 static const struct dmi_system_id uniwill_dmi_table[] __initconst = {
+	{
+		.ident = "AiStone X4SP4NAL",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "AiStone"),
+			DMI_EXACT_MATCH(DMI_BOARD_NAME, "X4SP4NAL"),
+		},
+		.driver_data = &x4sp4nal_descriptor,
+	},
 	{
 		.ident = "XMG FUSION 15",
 		.matches = {

--- a/uniwill-laptop.rst
+++ b/uniwill-laptop.rst
@@ -80,6 +80,10 @@ Keep in mind that due to hardware design choices, the driver does not support th
 ``0x000000`` (black), instead it will fall back to ``0x010101`` (faint white). In order to
 disable the keyboard backlight, the standard LED brightness setting has to be used instead.
 
+Some devices, such as the AiStone X4SP4NAL, require an initial press of the FN+Backlight button
+combo, before the brightness of the keyboard backlight can be controlled through the sysfs
+attributes provided by the ``uniwill-laptop`` driver.
+
 AC Auto Boot
 ------------
 


### PR DESCRIPTION
This patch adds an entry for AiStone X4SP4NAL devices.

As discussed in #9 I loaded the *uniwill_laptop* driver and tested the individual features. I'm happy to perform additional tests.

The following is a summary of my testing for each feature.

**✅ UNIWILL_FEATURE_FN_LOCK**
I can confirm that `echo 1 > /sys/bus/platform/devices/INOU0000\:00/fn_lock` disables the FN functionality of the F-keys. `echo 0 …` removes the lock as expected.

When the FN button is locked, the FN+F-key-presses behave as if the FN modifier wasn't pressed.

**✅ UNIWILL_FEATURE_SUPER_KEY**
`echo 0 > /sys/bus/platform/devices/INOU0000\:00/super_key_enable` prevents me from moving Windows around in KDE (Super + Arrow key) as expected. The Super key is reenabled with `echo 1 > /sys/bus/platform/devices/INOU0000\:00/super_key_enable` as expected.

**❌ UNIWILL_FEATURE_TOUCHPAD_TOGGLE**
I don't see any effect on pointer movements or touch gestures when flipping `/sys/bus/platform/devices/INOU0000:XX/touchpad_toggle_enable`.

**❌ UNIWILL_FEATURE_LIGHTBAR**
`/sys/bus/platform/devices/INOU0000\:00/rainbow_animation` was set to `1` by default. To my knowledge, my device doesn't have a lightbar and I didn't see any change when modifying the value.

**✅ UNIWILL_FEATURE_CPU_TEMP**
**✅ UNIWILL_FEATURE_PRIMARY_FAN**
**✅ UNIWILL_FEATURE_SECONDARY_FAN**

With the *uniwill_laptop* module loaded, I could see additional output in *sensors*:
```
# sensors
uniwill-isa-0000
Adapter: ISA adapter
Main:           0 RPM
Secondary:      0 RPM
CPU:          +42.0°C
GPU:           +0.0°C
pwm1:              0%
pwm2:              0%
```

I ran `stress -c 20` and observed that both the CPU temperature, the RPM values for *Main* and *Secondary* as well as their respective PWM values changed:
```
uniwill-isa-0000
Adapter: ISA adapter
Main:        2433 RPM
Secondary:   2067 RPM
CPU:          +58.0°C  
pwm1:             40%
pwm2:             34%
```

I also noticed that the CPU temperature is exactly the same as the *acpitz-acpi-0* sensor, which is also available without the *uniwill_laptop* driver. So at least for *sensors*, *UNIWILL_FEATURE_CPU_TEMP* doesn't add additional information.
```
acpitz-acpi-0
Adapter: ACPI interface
temp1:        +50.0°C
temp2:        +50.0°C
```

**❌ UNIWILL_FEATURE_GPU_TEMP**
The GPU temp was always reported as `0`. I assume it isn't applicable, because my device doesn't have a dedicated GPU.

**❌ UNIWILL_FEATURE_NVIDIA_CTGP_CONTROL**
My understanding is that this feature controls the power target of an Nvidia dGPU. My device doesn't have one, so I think it's not applicable.

**✅ UNIWILL_FEATURE_KEYBOARD_BACKLIGHT**
`cat /sys/class/leds/uniwill\:white\:kbd_backlight/brightness` reports brightness levels correctly when the keyboard brightness is controlled via the fn button.

⚠️ However, the fn button only cycles between three brightness levels (0–2), whereas `max_brightness` reports 4. Setting the value to anything higher than 2 is identical with setting it to 2.

⚠️ Interestingly, controlling keyboard brightness via `echo {0,1,2} > /sys/class/leds/uniwill\:white\:kbd_backlight/brightness` only worked _after_ I used the fn button. It had no effect before.

**❌ UNIWILL_FEATURE_AC_AUTO_BOOT**
I was unable to switch on ac_auto_boot in sysfs:
```
# echo 1 > /sys/bus/platform/devices/INOU0000\:00/ac_auto_boot
-bash: echo: write error: Input/output error
```
No relevant output in dmesg either.

**✅ UNIWILL_FEATURE_USB_POWER_SHARE**
`cat /sys/bus/platform/devices/INOU0000\:00/usb_powershare` initially reports `0`. Setting it to `1` and powering off the device allows me to charge my mobile phone on any of the USB ports.

⚠️ I found that the change is not persistent across reboots. That means next time I load the uniwill-laptop driver, `usb_powershare` is `0` again and USB ports no longer provide power when the laptop is powered off. I specifically tested setting the value to 1 and then to 0 before powering off. This worked as expected and there was no USB power.

**❌ UNIWILL_FEATURE_BATTERY_CHARGE_MODES**
Based on the description in *uniwill-laptop.rst*, my understanding is that the *current_now* sysfs attribute should report 0 when no charger is plugged in and the laptop solely runs on battery power. In my case, it reports relatively large values that I cannot really make sense of:
```
# cat /sys/class/power_supply/BAT0/current_now
239000
# cat /sys/class/power_supply/BAT0/current_now
375000
# cat /sys/class/power_supply/BAT0/current_now
307000
# cat /sys/class/power_supply/BAT0/current_now
239000
# cat /sys/class/power_supply/BAT0/current_now
239000
# cat /sys/class/power_supply/BAT0/current_now
273000
# cat /sys/class/power_supply/BAT0/current_now
273000
# cat /sys/class/power_supply/BAT0/current_now
307000
```

These get larger when the system is under load (`stress -c 20`):
```
# cat /sys/class/power_supply/BAT0/current_now
4659000
# cat /sys/class/power_supply/BAT0/current_now
4693000
# cat /sys/class/power_supply/BAT0/current_now
4149000
# cat /sys/class/power_supply/BAT0/current_now
4217000
```

These are the values I get when the system is idling again, but with a charger plugged in:
```
# cat /sys/class/power_supply/BAT0/current_now
0
# cat /sys/class/power_supply/BAT0/current_now
1802000
# cat /sys/class/power_supply/BAT0/current_now
2142000
# cat /sys/class/power_supply/BAT0/current_now
2176000
```

I'm not sure how to go about testing the battery charge modes from here. Any pointers? :)


**✅ UNIWILL_FEATURE_BATTERY_CHARGE_LIMIT**
A comment in the feature flags say that this is mutually exclusive with the battery charge modes. Since the charge limit is excluded when the module is loaded with the *force* parameter, I added a DMI table entry for my device along with a device descriptor that includes the charge limit feature.

The default charge threshold is 100%.
```
# cat /sys/class/power_supply/BAT0/charge_control_end_threshold
100
```

When the current capacity is higher than the current charge limit, the device maintains the current battery charge.
```
# echo 80 > /sys/class/power_supply/BAT0/charge_control_end_threshold
# cat /sys/class/power_supply/BAT0/charge_control_end_threshold
80
# cat /sys/class/power_supply/BAT0/capacity
91
# cat /sys/class/power_supply/BAT0/status
Not charging
```

When the current capacity is lower than the current charge limit, the device charges the battery:
```
# echo 93 > /sys/class/power_supply/BAT0/charge_control_end_threshold
# cat /sys/class/power_supply/BAT0/status
Charging
```

It stops when the charge limit is reached:
```
# cat /sys/class/power_supply/BAT0/status
Not charging
# cat /sys/class/power_supply/BAT0/capacity
93
```

Closes #9 