### PR TITLE
uniwill-laptop: enable UNIWILL_FEATURE_BATTERY on TUXEDO IBP 14/15 Gen10 AMD (XxKK4NAx_XxSP4NAx)

### DIFF
--- a/uniwill-acpi.c
+++ b/uniwill-acpi.c
@@ -1682,6 +1682,10 @@ static struct uniwill_device_descriptor tux_featureset_1_descriptor __initdata =
 	.features = UNIWILL_FEATURE_NVIDIA_CTGP_CONTROL
 };
 
+static struct uniwill_device_descriptor xxkk4nax_descriptor __initdata = {
+	.features = UNIWILL_FEATURE_BATTERY
+};
+
 static struct uniwill_device_descriptor empty_descriptor __initdata = {};
 
 static const struct dmi_system_id uniwill_dmi_table[] __initconst = {
@@ -1803,7 +1807,7 @@ static const struct dmi_system_id uniwill_dmi_table[] __initconst = {
 			DMI_MATCH(DMI_SYS_VENDOR, "TUXEDO"),
 			DMI_EXACT_MATCH(DMI_BOARD_NAME, "XxKK4NAx_XxSP4NAx"),
 		},
-		.driver_data = &empty_descriptor,
+		.driver_data = &xxkk4nax_descriptor,
 	},
 	{
 		.ident = "TUXEDO InfinityBook Pro 15 Gen10 Intel",


### PR DESCRIPTION
The board `XxKK4NAx_XxSP4NAx` (TUXEDO InfinityBook Pro 14/15 Gen10 AMD, Ryzen AI 9 HX 370) is already listed in `uniwill_dmi_table` with `&empty_descriptor`. This PR adds `&xxkk4nax_descriptor` with `UNIWILL_FEATURE_BATTERY` so `charge_control_end_threshold` sysfs lights up on this generation.

## Verification

The `EC_ADDR_CHARGE_CTRL` register (`0x07B9`, bits 0-6 = percent, bit 7 = reached) you already encode in the driver is honored by the EC firmware on this exact board (BIOS `N.1.20A13`). Confirmed via two independent paths:

1. **ACPI DSDT**: defines field `CGLM` at offset `0x07B9` inside `ECMG` SystemMemory OperationRegion (`0xFED50000`/`0x1000`), 7 bits wide. `BAT0._BST` reads `CGLM` and checks `<= 0x63 && >= 1` to set the limited-charge state bit. This is the same register your driver writes to.

2. **Direct EC write test** from userspace via a parallel patch to `tuxedocomputers/tuxedo-drivers` (PR pending) that exposes `charge_control_end_threshold` through the existing `uw_battery_hook`:

   - Before: `Charging` at 78%, `current_now=2142000` (2.14 A).
   - `echo 75 > charge_control_end_threshold`
   - Within 2 seconds: `status=Not charging`, `current_now=0`, capacity held at 78.
   - Set cap=80 from capacity=78 -> charged to exactly 80% and halted.

This contradicts a recurring "not supported on this device" line in TUXEDO support replies for Gen10 AMD (GitLab tuxedo-drivers#363 closed by `tuxedo_wse`, github tuxedo-control-center#344 by `crissi-tuxedo`, #411 by `tuxedoder`). The EC interface IS supported; the existing `stationary` charging profile mechanism on this firmware just doesn't propagate to `EC[0x07B9]`, leaving the cap byte at zero, hence the universal "battery charges to 100% regardless of stationary profile" symptom in `tuxedocomputers/tuxedo-control-center#268`.

## Scope

Only `UNIWILL_FEATURE_BATTERY` is enabled. Other Uniwill feature flags (`FN_LOCK_TOGGLE`, `SUPER_KEY_TOGGLE`, `TOUCHPAD_TOGGLE`, `HWMON`) have not been independently tested on Gen10 AMD through `uniwill-laptop` (the user currently runs `tuxedo-drivers` for those features) and can be added in follow-up patches when verified. Keeping this PR minimal.

## Caveat

The above verification was done via `tuxedo-drivers` with the same `EC[0x07B9]` access path. I have not yet swapped out `tuxedo-drivers` for `uniwill-laptop` on this board to verify your driver's full battery code path end-to-end (TCC dependency on tuxedo-drivers features prevents a clean swap right now). The EC register is confirmed working; if anything in your driver's BATTERY code path needs board-specific tweaks, that would surface as a separate bug after this descriptor is enabled.

Reference: github.com/tuxedocomputers/tuxedo-control-center/issues/268