### PR TITLE
uniwill-laptop: enable BATTERY_CHARGE_LIMIT in tux_featureset_3

### DIFF
--- a/uniwill-acpi.c
+++ b/uniwill-acpi.c
@@ -2552,6 +2552,7 @@ static struct uniwill_device_descriptor tux_featureset_2_nvidia_descriptor __ini
 static struct uniwill_device_descriptor tux_featureset_3_descriptor __initdata = {
 	.features = UNIWILL_FEATURE_FN_LOCK |
 		    UNIWILL_FEATURE_SUPER_KEY |
+		    UNIWILL_FEATURE_BATTERY_CHARGE_LIMIT |
 		    UNIWILL_FEATURE_CPU_TEMP |
 		    UNIWILL_FEATURE_PRIMARY_FAN |
 		    UNIWILL_FEATURE_SECONDARY_FAN |


### PR DESCRIPTION
`UNIWILL_FEATURE_BATTERY_CHARGE_LIMIT` is defined and fully wired up on this branch but no descriptor currently claims it. This PR enables it on `tux_featureset_3_descriptor` so the `XxKK4NAx_XxSP4NAx` board (TUXEDO InfinityBook Pro 14/15 Gen10 AMD, Ryzen AI 9 HX 370) gets a working `charge_control_end_threshold` sysfs.

## Verification

`EC_ADDR_CHARGE_CTRL` (`0x07B9`, bits 0-6 = percent, bit 7 = reached) is the correct register on this exact board (BIOS `N.1.20A13`). Confirmed via two independent paths:

1. The laptop's own ACPI DSDT declares the same offset as field `CGLM` inside the `ECMG` `SystemMemory` `OperationRegion` (`0xFED50000`/`0x1000`), 7 bits wide:

   ```
   Offset (0x7B9),
   CGLM,   7,
   ```

   `BAT0._BST` reads `CGLM` and uses it for the limited-charge state bit.

2. Direct EC write test from userspace via a parallel patch to `tuxedo-drivers` (tuxedocomputers/tuxedo-drivers#4) using the same `uniwill_write_ec_ram(0x07B9, ...)` access path:

   - Before: `status=Charging`, capacity=78%, `current_now=2142000` (2.14 A).
   - `echo 75 > charge_control_end_threshold`
   - Within 2 s: `status=Not charging`, `current_now=0`, capacity held at 78.
   - Then cap=80 from capacity=78: charged to exactly 80% and halted.

Bidirectional enforcement confirmed.

## Why this matters

The `stationary` charging profile (`EC[0x07a6]` bits 4-5) does NOT propagate to `EC[0x07B9]` on this firmware family. The cap byte sits at zero by default. That is the mechanism behind the universal "battery charges to 100% despite stationary" symptom in `tuxedocomputers/tuxedo-control-center#268` (open since Jan 2023, 39 comments across IBP Pro Gen7 through Gen10 AMD). Three separate TUXEDO staff replies in three repos have claimed the standard `charge_control_*_threshold` interface "is not supported by this device" - that is factually incorrect on Gen10 AMD: the interface is supported by the EC firmware, but `tuxedo-drivers` (and `uniwill-laptop` until this commit) simply don't write to it.

## Scope

Conservatively limited to `tux_featureset_3_descriptor` only. Other Tuxedo descriptors in this branch share the same EC firmware family and likely benefit from the same flag, but I haven't independently verified them and am keeping this PR narrow. Happy to follow up on user reports.

Reference: github.com/tuxedocomputers/tuxedo-control-center/issues/268
Closes (supersedes): #15